### PR TITLE
ci: bump checkout v3 & psalm 5.18.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['5.x', '7.x', '8.x']
+        php-versions: ['7.x', '8.x']
     name: Testing PHP ${{ matrix.php-versions }}
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     name: Testing PHP ${{ matrix.php-versions }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -29,7 +29,7 @@ jobs:
     name: TypeChecks against PSALM
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -39,6 +39,6 @@ jobs:
       - name: Install Dependencies
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
       - name: Downloading
-        run: wget https://github.com/vimeo/psalm/releases/download/5.9.0/psalm.phar
+        run: wget https://github.com/vimeo/psalm/releases/download/5.18.0/psalm.phar
       - name: Typechecking
         run: php psalm.phar

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "ext-json": "*",
         "guzzlehttp/psr7": "^1.6",
-        "php": "^5.6 || ^7.0 || ^8.0",
+        "php": "^7.0 || ^8.0",
         "php-http/httplug": ">=1.1.0"
     },
     "suggest": {

--- a/src/VaultPHP/VaultClient.php
+++ b/src/VaultPHP/VaultClient.php
@@ -3,7 +3,7 @@
 namespace VaultPHP;
 
 use GuzzleHttp\Psr7\Request;
-use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use VaultPHP\Authentication\AuthenticationMetaData;
@@ -27,7 +27,7 @@ class VaultClient
     /** @var string */
     private $apiHost;
 
-    /** @var HttpClient */
+    /** @var ClientInterface */
     private $httpClient;
 
     /** @var AuthenticationProviderInterface */
@@ -38,12 +38,12 @@ class VaultClient
 
     /**
      * VaultClient constructor.
-     * @param HttpClient $httpClient
+     * @param ClientInterface $httpClient
      * @param AuthenticationProviderInterface $authProvider
      * @param string $apiHost
      */
     public function __construct(
-        HttpClient $httpClient,
+        ClientInterface $httpClient,
         AuthenticationProviderInterface $authProvider,
         $apiHost
     )

--- a/tests/VaultPHP/Exceptions/ExceptionsTest.php
+++ b/tests/VaultPHP/Exceptions/ExceptionsTest.php
@@ -3,7 +3,7 @@
 namespace Test\VaultPHP\Response;
 
 use GuzzleHttp\Psr7\Response;
-use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -37,7 +37,7 @@ final class ExceptionsTest extends TestCase
         $this->expectExceptionMessage('can\'t parse provided apiHost - malformed uri');
 
         $auth = new Token('fooToken');
-        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient = $this->createMock(ClientInterface::class);
 
         $client = new VaultClient($httpClient, $auth, "imInvalidHost");
         $client->sendApiRequest('LOL', '/i/should/be/preserved', EndpointResponse::class, ['dontReplaceMe']);
@@ -46,7 +46,7 @@ final class ExceptionsTest extends TestCase
     public function testAuthenticateWillThrowWhenNoTokenIsReturned() {
         $this->expectException(VaultAuthenticationException::class);
 
-        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient = $this->createMock(ClientInterface::class);
         $httpClient
             ->expects($this->once())
             ->method('sendRequest')
@@ -61,7 +61,7 @@ final class ExceptionsTest extends TestCase
     public function testWillThrowWhenAPIReturns403() {
         $this->expectException(VaultAuthenticationException::class);
 
-        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient = $this->createMock(ClientInterface::class);
         $auth = $this->createMock(AuthenticationProviderInterface::class);
         $auth
             ->expects($this->once())
@@ -76,7 +76,7 @@ final class ExceptionsTest extends TestCase
         $this->expectException(VaultHttpException::class);
         $this->expectExceptionMessage('foobarMessage');
 
-        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient = $this->createMock(ClientInterface::class);
         $httpClient
             ->expects($this->once())
             ->method('sendRequest')
@@ -100,7 +100,7 @@ final class ExceptionsTest extends TestCase
         $this->expectException(VaultException::class);
         $this->expectExceptionMessage('Return Class declaration lacks static::fromResponse');
 
-        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient = $this->createMock(ClientInterface::class);
         $httpClient
             ->expects($this->once())
             ->method('sendRequest')
@@ -121,7 +121,7 @@ final class ExceptionsTest extends TestCase
         $this->expectException(VaultException::class);
         $this->expectExceptionMessage('Return Class declaration lacks static::fromBulkResponse');
 
-        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient = $this->createMock(ClientInterface::class);
         $httpClient
             ->expects($this->once())
             ->method('sendRequest')
@@ -142,7 +142,7 @@ final class ExceptionsTest extends TestCase
         $this->expectException(VaultException::class);
         $this->expectExceptionMessage('Result from "fromResponse/fromBulkResponse" isn\'t an instance of EndpointResponse');
 
-        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient = $this->createMock(ClientInterface::class);
         $httpClient
             ->expects($this->once())
             ->method('sendRequest')

--- a/tests/VaultPHP/SecretEngines/AbstractSecretEngineTestCase.php
+++ b/tests/VaultPHP/SecretEngines/AbstractSecretEngineTestCase.php
@@ -3,7 +3,7 @@
 namespace Test\VaultPHP\SecretEngines;
 
 use GuzzleHttp\Psr7\Response;
-use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use VaultPHP\Authentication\Provider\Token;
@@ -17,7 +17,7 @@ abstract class AbstractSecretEngineTestCase extends TestCase
 {
     protected function createApiClient($expectedMethod, $expectedPath, $expectedData, $responseData, $responseStatus = 200)
     {
-        $httpMock = $this->createMock(HttpClient::class);
+        $httpMock = $this->createMock(ClientInterface::class);
         $httpMock
             ->expects($this->once())
             ->method('sendRequest')

--- a/tests/VaultPHP/TestHelperTrait.php
+++ b/tests/VaultPHP/TestHelperTrait.php
@@ -3,7 +3,7 @@
 namespace Test\VaultPHP;
 
 use GuzzleHttp\Psr7\Response;
-use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
 use VaultPHP\Authentication\Provider\Token;
 use VaultPHP\Response\EndpointResponse;
 use VaultPHP\VaultClient;
@@ -29,7 +29,7 @@ trait TestHelperTrait {
         $response = new Response($responseStatus, $responseHeader, $responseBody);
         $auth = new Token('fooToken');
 
-        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient = $this->createMock(ClientInterface::class);
 
         $httpClient
             ->expects($this->once())

--- a/tests/VaultPHP/VaultClientTest.php
+++ b/tests/VaultPHP/VaultClientTest.php
@@ -3,7 +3,7 @@
 namespace Test\VaultPHP;
 
 use GuzzleHttp\Psr7\Response;
-use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Test\VaultPHP\Mocks\EndpointResponseMock;
@@ -23,7 +23,7 @@ final class VaultClientTest extends TestCase
     public function testAuthProviderGetsClientInjected()
     {
         $auth = new Token('foo');
-        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient = $this->createMock(ClientInterface::class);
         $client = new VaultClient($httpClient, $auth, TEST_VAULT_ENDPOINT);
 
         $this->assertSame($client, $auth->getVaultClient());
@@ -32,7 +32,7 @@ final class VaultClientTest extends TestCase
     public function testRequestWillExtendedWithDefaultVars() {
         $auth = new Token('fooToken');
 
-        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient = $this->createMock(ClientInterface::class);
         $httpClient
             ->expects($this->once())
             ->method('sendRequest')
@@ -61,7 +61,7 @@ final class VaultClientTest extends TestCase
     public function testSendRequest() {
         $response = new Response();
 
-        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient = $this->createMock(ClientInterface::class);
         $httpClient
             ->expects($this->once())
             ->method('sendRequest')


### PR DESCRIPTION
Just do some minor updates:
- [x] bump actions/checkout@v3 & psalm 5.18.0
- [x] use Psr\Http\Client\ClientInterface instead of deprecated Http\Client\HttpClient
- [x] exclude PHP 5.x due to unsupported Psr\Http\Client\ClientInterface (it seems unavoidable)